### PR TITLE
Make #is conditions of sections use name rather than ID

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "GDS Style",
   "author": "Ben Arnold",
-  "version": "1.9.8",
+  "version": "1.9.9",
   "api_version": 1,
   "default_locale": "en-gb",
   "settings": [

--- a/templates/article_page.hbs
+++ b/templates/article_page.hbs
@@ -1,6 +1,6 @@
 <div id="main-content" class="govuk-width-container">
   
-{{#is section.id settings.article_id_apprentice }}
+{{#is section.name 'Apprentice' }}
 	{{! Apprentices Articles -- }}
   <a  class='govuk-back-link' href="/hc/en-gb/sections/{{settings.article_id_apprentice}}-Apprentice">Apprentice</a>
   <style>.hide-for-apprentices { display: none; }</style>

--- a/templates/section_page.hbs
+++ b/templates/section_page.hbs
@@ -1,7 +1,7 @@
 <div class="govuk-width-container">
   
 <!-- Apprentice Articles -->
-{{#is section.id settings.article_id_apprentice }}
+{{#is section.name 'Apprentice' }}
   <style>.hide-for-apprentices { display: none; }</style>
 {{else}}
   {{#link 'help_center' class='govuk-back-link'}}
@@ -10,7 +10,7 @@
 {{/is}}
   
 <!-- Coronavirus Promoted Articles -->
-{{#is section.id settings.article_id_covid19 }}
+{{#is section.name 'Coronavirus' }}
     
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
@@ -38,7 +38,7 @@
 <!-- Coronavirus Promoted Articles -->
 
 <!-- Apprentice Promoted Articles -->
-{{#is section.id settings.article_id_apprentice }} 
+{{#is section.name 'Apprentice' }}
     
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
@@ -91,7 +91,7 @@
 </div>      
   
 <!-- Apprentices Articles -->
-{{#is section.id settings.article_id_apprentice }} 
+{{#is section.name 'Apprentice' }}
 <hr />  
 <section class="app-section">
   <div class="govuk-width-container">


### PR DESCRIPTION
Zendesk cannot compare string/number for equality - `{{#is 0 '0'}}` will never succeed.  The template variables must be strings, and the section IDs are numbers.  Therefore we cannot use the section IDs against variables configured per environment, so we must use the section names.

On the plus side, these do not need to be configured per environment as the sections have the same names in each.  On the other hand, it does restrict the section names to being unique.