### PR TITLE
🐛Correctly emit Google tag manager ID

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "GDS Style",
   "author": "Ben Arnold",
-  "version": "1.9.20",
+  "version": "1.9.21",
   "api_version": 1,
   "default_locale": "en-gb",
   "settings": [

--- a/templates/document_head.hbs
+++ b/templates/document_head.hbs
@@ -11,7 +11,7 @@
 new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
 j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','settings.google_tag_manager_id');</script>
+})(window,document,'script','dataLayer','{{settings.google_tag_manager_id}}');</script>
 <!-- End Google Tag Manager -->
 {{/if}}
 


### PR DESCRIPTION
The GTM ID is not being emitted by the theme as the variable is not surrounded with braces.

![image](https://user-images.githubusercontent.com/201727/88046793-8359b680-cb48-11ea-93fd-843030994df8.png)
