### PR TITLE
AD-2250 amendment to contact times on the homepage

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "GDS Style",
   "author": "Ben Arnold",
-  "version": "1.9.26",
+  "version": "1.9.27",
   "api_version": 1,
   "default_locale": "en-gb",
   "settings": [

--- a/templates/home_page.hbs
+++ b/templates/home_page.hbs
@@ -89,7 +89,7 @@
       <div class="govuk-grid-column-full"> 
 
         <h2 class="govuk-heading-l" id="contact-us">Contact us</h2>
-        <p class="govuk-body">Our opening times are 8am to 8pm Monday to Friday.</p>
+        <p class="govuk-body">Our opening times are 8am to 8pm, Monday to Friday and 9 am to 1 pm on Saturday.</p>
         <div class="das-cards">
 
           <div class="das-card app-card">


### PR DESCRIPTION
Amended from: "Our opening times are 8am to 8pm Monday to Friday."
to: "Our opening times are 8am to 8pm, Monday to Friday and 9 am to 1 pm on Saturday."
