### PR TITLE
AD-2307 Remove R14 banner

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "GDS Style",
   "author": "Ben Arnold",
-  "version": "1.9.34",
+  "version": "1.9.35",
   "api_version": 1,
   "default_locale": "en-gb",
   "settings": [

--- a/style.css
+++ b/style.css
@@ -880,7 +880,3 @@ iframe#launcher.zEWidget-launcher.zEWidget-launcher--active {
 .govuk-list> li:nth-child(1n+4) .article-link {
   display: none;
 }
-
-.promotion-banner {
-  color: #fff  !important;
-}

--- a/templates/home_page.hbs
+++ b/templates/home_page.hbs
@@ -91,14 +91,13 @@
         <div class="govuk-grid-column-full">  
 
           <h2 class="govuk-heading-m app-heading--section-blue">Get ready for R14</h2>
-          <p class="govuk-body promotion-banner">
-            <a class="govuk-link promotion-banner" href="https://help.apprenticeships.education.gov.uk/hc/en-gb/articles/360016114880-Get-your-data-right-for-R14">Training Providers</a> - you must submit your final
-            <abbr title="Individualised Learner Record">ILR</abbr> for the 2019 to 2020 academic year (R14) by 6pm on 22
-            October 2020. Check that all apprentice data is correct before you submit.
+          <p class="govuk-body" style="color: #fff;"><a class="govuk-link" href="https://help.apprenticeships.education.gov.uk/hc/en-gb/articles/360016114880-Get-your-data-right-for-R14" style="color:#fff;">Training 					Providers</a> - you must submit your final <abbr title="Individualised Learner Record">ILR</abbr> for the 2019 to 2020 academic year (R14) by 6pm on 22
+          October 2020. Check that all apprentice data is correct before you submit.
           <br>
           <br>
-          <a class="govuk-link article-link promotion-banner" href="https://help.apprenticeships.education.gov.uk/hc/en-gb/articles/360016114900-Get-ready-for-R14">Employers</a> - Check that all apprentice data is 					 correct in your apprenticeship service account.
+          <a class="govuk-link article-link" href="https://help.apprenticeships.education.gov.uk/hc/en-gb/articles/360016114900-Get-ready-for-R14" style="color:#fff;">Employers</a> - Check that all apprentice data is 					 correct in your apprenticeship service account.
           </p>
+          
         </div>
       </div>
       

--- a/templates/home_page.hbs
+++ b/templates/home_page.hbs
@@ -83,27 +83,26 @@
   </div>
 </section>
 
-<!-- ****** R14 promotional banner start ****** -->
+
+<!-- ****** cronavirus articles start ****** -->
 <section class="app-section govuk-width-container" style="padding-top: 0;">
     <div class="app-section--blue" style="padding: 25px 25px 10px 25px; margin-top: 0;">
       
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">  
 
-          <h2 class="govuk-heading-m app-heading--section-blue">Get ready for R14</h2>
-          <p class="govuk-body" style="color: #fff;"><a class="govuk-link" href="https://help.apprenticeships.education.gov.uk/hc/en-gb/articles/360016114880-Get-your-data-right-for-R14" style="color:#fff;">Training 					Providers</a> - you must submit your final <abbr title="Individualised Learner Record">ILR</abbr> for the 2019 to 2020 academic year (R14) by 6pm on 22
-          October 2020. Check that all apprentice data is correct before you submit.
-          <br>
-          <br>
-          <a class="govuk-link article-link" href="https://help.apprenticeships.education.gov.uk/hc/en-gb/articles/360016114900-Get-ready-for-R14" style="color:#fff;">Employers</a> - Check that all apprentice data is 					 correct in your apprenticeship service account.
-          </p>
+          <h2 class="govuk-heading-m app-heading--section-blue">Looking for articles related to Coronavirus (COVID-19)?</h2>
           
+          <p class="govuk-body" style="color: #fff;">We have a section where you can 
+            <a href="/hc/en-gb/sections/{{settings.article_id_covid19}}-Coronavirus" class="govuk-link" style="color: inherit;">check how the apprenticeship service will support you</a>. 
+          </p>
+
         </div>
       </div>
       
     </div>
 </section>
-<!-- ****** R14 promotional banner ends ****** -->
+<!-- ****** cronavirus articles ends ****** -->
 
 <section class="app-section">
   <div class="govuk-width-container">


### PR DESCRIPTION
The R14 banner is no longer appropriate from COB 2020-10-21.  This PR simply reverts the commits that added the R14 banner.