### PR TITLE
FJA 39 update banner on help article page

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "GDS Style",
   "author": "Ben Arnold",
-  "version": "1.9.42",
+  "version": "1.9.43",
   "api_version": 1,
   "default_locale": "en-gb",
   "settings": [

--- a/templates/home_page.hbs
+++ b/templates/home_page.hbs
@@ -1,3 +1,20 @@
+<!-- ****** Browser Support Banner ****** -->
+<section class="app-section govuk-width-container" style="padding-top: 0; padding-bottom: 0;">
+<div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+  <div class="govuk-notification-banner__header">
+    <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+      Important
+    </h2>
+  </div>
+  <div class="govuk-notification-banner__content">
+    <p class="govuk-notification-banner__heading">
+      From 31st of July 2022 the Apprenticeship Service will no longer support the use of some older browsers including Internet Explorer and older versions of Safari. To continue to use our service you will need to use a different browser.
+    </p>
+  </div>
+</div>
+</section>
+<!-- ****** browser support ends ****** -->
+
 <section class="app-section app-section--blue govuk-!-margin-top-3">
   <div class="govuk-width-container">
     <div class="govuk-grid-row">

--- a/templates/home_page.hbs
+++ b/templates/home_page.hbs
@@ -59,25 +59,6 @@
   </div>
 </section>
 
-
-<!-- ****** R14 Banner ****** -->
-<section class="app-section govuk-width-container" style="padding-top: 0;">
-    <div class="app-section--blue" style="padding: 25px 25px 10px 25px; margin-top: 0;">      
-      <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full">  
-          <p class="govuk-body" style="color: #fff;">
-          We are currently receiving high demand of queries and are working hard
-          to respond to our customers. We will review your message and respond
-          to you as quickly as possible. If you have already been in contact
-          with us and are chasing a response we apologise and assure you we will
-          be in touch as soon as possible.
-        </p>
-        </div>
-      </div>      
-    </div>
-</section>
-<!-- ****** cronavirus articles ends ****** -->
-
 <section class="app-section">
   <div class="govuk-width-container">
 


### PR DESCRIPTION
Removed the "expect delays due to covid" banner and added the "end of browser support 31st July 2022" banner on the home_page.hbs